### PR TITLE
Track vendor directory in version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 composer.phar
-/vendor/
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file


### PR DESCRIPTION
Fixes:
Fatal error: require_once(): Failed opening required '/code/private/scripts/quicksilver-wpmu-db-clone/vendor/autoload.php' (include_path='.:/usr/share/pear:/usr/share/php') in /code/private/scripts/quicksilver-wpmu-db-clone/wpmu-db-clone.php on line 8